### PR TITLE
Add simple REPL functionality

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(quickstart)
+add_subdirectory(repl)

--- a/examples/repl/CMakeLists.txt
+++ b/examples/repl/CMakeLists.txt
@@ -1,0 +1,12 @@
+project(kalcy-repl)
+
+add_executable(${PROJECT_NAME})
+
+target_link_libraries(${PROJECT_NAME} PRIVATE
+  kalcy::kalcy
+  kalcy::kalcy-compile-options
+)
+
+target_sources(${PROJECT_NAME} PRIVATE
+  repl.cpp
+)

--- a/examples/repl/repl.cpp
+++ b/examples/repl/repl.cpp
@@ -1,0 +1,59 @@
+#include <kalcy/kalcy.hpp>
+#include <cassert>
+#include <format>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+
+namespace {
+struct Repl {
+	const std::string_view EXIT_TOKEN{"exit"};
+	bool verbose{}; // toggled on with '-v' and off with '-q'
+	bool is_running{true};
+
+	auto start() -> bool {
+		while (is_running) {
+			std::string text{};
+			std::cout << std::format("[{}] > ", verbose ? "verbose" : "quiet");
+			std::getline(std::cin, text);
+			// run kalcy on input expression
+			if (!run(text)) { return EXIT_FAILURE; }
+		}
+		// print epilogue
+		std::cout << std::format("\n^^ kalcy v{}\n", kalcy::version_v);
+	}
+
+	auto run(std::string_view const text) -> bool {
+		try {
+			// return false when the user enters the exit token
+			if (text == EXIT_TOKEN) {
+				is_running = false;
+			} else if (text == "-v") {
+				verbose = !verbose;
+			}  else {
+				// parse text into an expression
+				auto expr = kalcy::Parser{}.parse(text);
+				assert(expr != nullptr);
+				// evaluate parsed expression
+				// a custom Env can be used and passed, if desired
+				std::cout << kalcy::evaluate(*expr) << "\n";
+				// print AST if verbose
+				if (verbose) { std::cout << std::format("expression\t: {}\nAST\t\t: {}\n", text, kalcy::to_string(*expr)); }
+			}
+			return true;
+		} catch (kalcy::Error const& err) {
+			// print error
+			std::cerr << err.what() << "\n";
+			// highlight error location under text
+			std::cerr << " | " << text << "\n | " << err.build_highlight() << "\n";
+			return false;
+		}
+	}
+};
+} // namespace
+
+auto main(int argc, char** argv) -> int {
+
+	Repl repl{};
+	repl.start();
+}

--- a/examples/repl/repl.cpp
+++ b/examples/repl/repl.cpp
@@ -14,8 +14,8 @@ struct Repl {
 	auto  print_help() const -> void {
 		std::cout << "Usage: [OPTION] | [EXPRESSION]\n";
 		std::cout << "\nDescription:\n\n";
-		std::cout << std::format("  {:<15} {}\n", "-h, -help", "Display this help message, providing information about available options.");
-		std::cout << std::format("  {:<15} {}\n", "-v", "Toggle verbose mode to control the level of detail in the output.");
+		std::cout << std::format("  {:<15} {}\n", "-h, --help", "Display this help message, providing information about available options.");
+		std::cout << std::format("  {:<15} {}\n", "-v, --verbose", "Toggle verbose mode to control the level of detail in the output.");
 		std::cout << std::format("  {:<15} {}\n\n", "exit", "Terminate the REPL input loop.");
 	}
 
@@ -42,12 +42,12 @@ struct Repl {
 				return true;
 			}
 
-			if (text == "-h" || text == "-help") {
+			if (text == "-h" || text == "--help") {
 				print_help();
 				return true;
 			}
 
-			if (text == "-v") {
+			if (text == "-v" || text == "--verbose") {
 				verbose = !verbose;
 				return true;
 			}

--- a/examples/repl/repl.cpp
+++ b/examples/repl/repl.cpp
@@ -7,17 +7,28 @@
 
 namespace {
 struct Repl {
-	const std::string_view EXIT_TOKEN{"exit"};
 	bool verbose{}; // toggled on with '-v' and off with '-q'
 	bool is_running{true};
+
+	auto print_help() -> void {
+		std::cout << "Usage: [OPTION] | [EXPRESSION]\n";
+		std::cout << "\nDescription:\n\n";
+		std::cout << std::format("  {:<15} {}\n", "-h, --help", "Display this help message, providing information about available options.");
+		std::cout << std::format("  {:<15} {}\n", "-v", "Toggle verbose mode to control the level of detail in the output.");
+		std::cout << std::format("  {:<15} {}\n", "exit", "Terminate the REPL input loop.");
+	}
 
 	auto start() -> bool {
 		while (is_running) {
 			std::string text{};
-			std::cout << std::format("[{}] > ", verbose ? "verbose" : "quiet");
+			std::cout << std::format("{} > ", verbose ? "[verbose]" : "");
 			std::getline(std::cin, text);
 			// run kalcy on input expression
-			if (!run(text)) { return EXIT_FAILURE; }
+			if (!text.empty()) {
+				if (!run(text)) { return EXIT_FAILURE; }
+			} else {
+				print_help();
+			}
 		}
 		// print epilogue
 		std::cout << std::format("\n^^ kalcy v{}\n", kalcy::version_v);
@@ -26,12 +37,13 @@ struct Repl {
 
 	auto run(std::string_view const text) -> bool {
 		try {
-			// return false when the user enters the exit token
-			if (text == EXIT_TOKEN) {
+			if (text == "exit") {
 				is_running = false;
 			} else if (text == "-v") {
 				verbose = !verbose;
-			}  else {
+			} else if (text == "-h" || text == "-help") {
+				print_help();
+			} else {
 				// parse text into an expression
 				auto expr = kalcy::Parser{}.parse(text);
 				assert(expr != nullptr);
@@ -53,8 +65,8 @@ struct Repl {
 };
 } // namespace
 
-auto main(int argc, char** argv) -> int {
+auto main() -> int {
 
 	Repl repl{};
-	return repl.start();
+	repl.start();
 }

--- a/examples/repl/repl.cpp
+++ b/examples/repl/repl.cpp
@@ -21,6 +21,7 @@ struct Repl {
 		}
 		// print epilogue
 		std::cout << std::format("\n^^ kalcy v{}\n", kalcy::version_v);
+		return EXIT_SUCCESS;
 	}
 
 	auto run(std::string_view const text) -> bool {
@@ -55,5 +56,5 @@ struct Repl {
 auto main(int argc, char** argv) -> int {
 
 	Repl repl{};
-	repl.start();
+	return repl.start();
 }

--- a/examples/repl/repl.cpp
+++ b/examples/repl/repl.cpp
@@ -11,7 +11,7 @@ struct Repl {
 	bool is_running{true};
 	kalcy::Parser parser{};
 
-	auto print_help() -> void {
+	auto  print_help() const -> void {
 		std::cout << "Usage: [OPTION] | [EXPRESSION]\n";
 		std::cout << "\nDescription:\n\n";
 		std::cout << std::format("  {:<15} {}\n", "-h, -help", "Display this help message, providing information about available options.");
@@ -19,21 +19,20 @@ struct Repl {
 		std::cout << std::format("  {:<15} {}\n\n", "exit", "Terminate the REPL input loop.");
 	}
 
-	auto start() -> bool {
+	auto start() -> void {
 		while (is_running) {
 			auto text = std::string{};
 			std::cout << std::format("{} > ", verbose ? "[verbose]" : "");
 			std::getline(std::cin, text);
 			// run kalcy on input expression
 			if (!text.empty()) {
-				if (!run(text)) { return EXIT_FAILURE; }
+				run(text);
 			} else {
 				print_help();
 			}
 		}
 		// print epilogue
 		std::cout << std::format("\n^^ kalcy v{}\n", kalcy::version_v);
-		return true;
 	}
 
 	auto run(std::string_view const text) -> bool {
@@ -50,17 +49,18 @@ struct Repl {
 
 			if (text == "-v") {
 				verbose = !verbose;
-			} else {
-				// parse text into an expression
-				auto expr = parser.parse(text);
-				assert(expr != nullptr);
-				// evaluate parsed expression
-				// a custom Env can be used and passed, if desired
-				std::cout << kalcy::evaluate(*expr) << "\n";
-				// print AST if verbose
-				if (verbose) { std::cout << std::format("expression\t: {}\nAST\t\t: {}\n", text, kalcy::to_string(*expr)); }
 				return true;
 			}
+			// parse text into an expression
+			auto expr = parser.parse(text);
+			assert(expr != nullptr);
+			// evaluate parsed expression
+			// a custom Env can be used and passed, if desired
+			std::cout << kalcy::evaluate(*expr) << "\n";
+			// print AST if verbose
+			if (verbose) { std::cout << std::format("expression\t: {}\nAST\t\t: {}\n", text, kalcy::to_string(*expr)); }
+			return true;
+
 		} catch (kalcy::Error const& err) {
 			// print error
 			std::cerr << err.what() << "\n";


### PR DESCRIPTION
Adding simple REPL example that resolves #2 
Enable toggling `verbose` mode on and off using `-v` and listing commands using `-help`