### PR TITLE
Fix issues with "-".

### DIFF
--- a/kalcy/src/scanner.cpp
+++ b/kalcy/src/scanner.cpp
@@ -24,8 +24,8 @@ auto Scanner::next() -> Token {
 	if (at_end()) { return {}; }
 
 	auto out = Token{};
-	if (match_number(out)) { return out; }
 	if (match_single(out)) { return out; }
+	if (match_number(out)) { return out; }
 	if (match_identifier(out)) { return out; }
 
 	return {};

--- a/tests/tests/test_parser.cpp
+++ b/tests/tests/test_parser.cpp
@@ -34,7 +34,7 @@ ADD_TEST(ParseUnary) {
 }
 
 ADD_TEST(ParseBinary) {
-	auto result = parse("3+2");
+	auto result = parse("3 -2");
 	ASSERT(result != nullptr);
 	ASSERT(std::holds_alternative<expr::Binary>(*result));
 	auto const& binary = std::get<expr::Binary>(*result);
@@ -45,7 +45,7 @@ ADD_TEST(ParseBinary) {
 	EXPECT(literal.token.type == Token::Type::eNumber);
 	EXPECT(literal.token.value == 3.0); // NOLINT
 
-	EXPECT(binary.op.type == Token::Type::ePlus);
+	EXPECT(binary.op.type == Token::Type::eMinus);
 
 	ASSERT(binary.right != nullptr);
 	ASSERT(std::holds_alternative<expr::Literal>(*binary.right));
@@ -77,8 +77,12 @@ ADD_TEST(ParseCall) {
 	ASSERT(std::holds_alternative<expr::Literal>(*pow_call.arguments[0]));
 	EXPECT(std::get<expr::Literal>(*pow_call.arguments[0]).token.value == 42); // NOLINT
 	ASSERT(pow_call.arguments[1] != nullptr);
-	ASSERT(std::holds_alternative<expr::Literal>(*pow_call.arguments[1]));
-	EXPECT(std::get<expr::Literal>(*pow_call.arguments[1]).token.value == -5); // NOLINT
+	ASSERT(std::holds_alternative<expr::Unary>(*pow_call.arguments[1]));
+	auto const& minus_5 = std::get<expr::Unary>(*pow_call.arguments[1]);
+	EXPECT(minus_5.op.type == Token::Type::eMinus);
+	ASSERT(minus_5.right != nullptr);
+	ASSERT(std::holds_alternative<expr::Literal>(*minus_5.right));
+	EXPECT(std::get<expr::Literal>(*minus_5.right).token.value == 5); // NOLINT
 }
 
 ADD_TEST(ParseErrorOnExtraneous) {

--- a/tests/tests/test_scanner.cpp
+++ b/tests/tests/test_scanner.cpp
@@ -36,8 +36,7 @@ ADD_TEST(ScanIdentifiers) {
 
 ADD_TEST(ScanNumbers) {
 	EXPECT(match_number("3", 3));
-	EXPECT(match_number("-42", -42));
-	EXPECT(match_number("-4.2", -4.2)); // NOLINT
+	EXPECT(match_number("4.2", 4.2)); // NOLINT
 }
 
 ADD_TEST(ScanMultiple) {


### PR DESCRIPTION
Scan "-2" as two tokens: "-" and "2". This fixes issues with parsing "3 -2" etc.

```
./kalcy-quickstart  "3 -2"
1
```
